### PR TITLE
Always write out global section first in format function

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -244,10 +244,15 @@ func (dict Dict) String() string {
 
 func (dict Dict) format() *bytes.Buffer {
 	var buffer bytes.Buffer
+	for key, val := range dict[""] {
+		buffer.WriteString(fmt.Sprintf("%s = %s\n", key, val))
+	}
+	buffer.WriteString("\n")
 	for section, vals := range dict {
-		if section != "" {
-			buffer.WriteString(fmt.Sprintf("[%s]\n", section))
+		if section == "" {
+			continue
 		}
+		buffer.WriteString(fmt.Sprintf("[%s]\n", section))
 		for key, val := range vals {
 			buffer.WriteString(fmt.Sprintf("%s = %s\n", key, val))
 		}


### PR DESCRIPTION
HI there.  In writing a better for for the section name nondeterminism problem I discovered that the format() function suffers from something similar.  This patch ensures that the global section is always written out first.  Failing to do this sometimes results occasionally in the global keys being part of some other section.