### PR TITLE
Move trim before line length check

### DIFF
--- a/ini.go
+++ b/ini.go
@@ -51,11 +51,12 @@ func LoadReader(reader *bufio.Reader) (dict Dict, err error) {
 			break
 		}
 		lineno++
-		if len(l) == 0 {
+		
+		line := strings.TrimFunc(string(l), unicode.IsSpace)
+		if len(line) == 0 {
 			continue
 		}
-		line := strings.TrimFunc(string(l), unicode.IsSpace)
-
+		
 		for line[len(line)-1] == '\\' {
 			line = line[:len(line)-1]
 			l, _, err := reader.ReadLine()

--- a/ini_test.go
+++ b/ini_test.go
@@ -1,10 +1,11 @@
 package ini
 
 import (
-	"io/ioutil"
-	"testing"
-	"strings"
 	"bufio"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
 )
 
 var (
@@ -19,6 +20,17 @@ func init() {
 func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Error("Example: load error:", err)
+	}
+}
+
+func TestLoadFileWithSpaces(t *testing.T) {
+	if err := ioutil.WriteFile("testLoadFileWithSpaces.ini", []byte(" "), 0777); err != nil {
+		t.Error("Unable to write test file")
+	}
+	defer os.Remove("testLoadFileWithSpaces.ini")
+
+	if _, err := Load("testLoadFileWithSpaces.ini"); err != nil {
+		t.Error("Load: Couldn't load ini file with line consisting only of spaces.")
 	}
 }
 
@@ -162,18 +174,18 @@ func TestString(t *testing.T) {
 	}
 	s, found := d2.GetString("section1", "key1")
 	if !found || s != "value2" {
-	        t.Error("Stringify failed for section1, key1")
+		t.Error("Stringify failed for section1, key1")
 	}
 	i, found := d2.GetInt("section1", "key2")
 	if !found || i != 5 {
-	        t.Error("Stringify failed for section1, key2")
+		t.Error("Stringify failed for section1, key2")
 	}
 	db, found := d2.GetDouble("section1", "key3")
 	if !found || db != 1.3 {
-	        t.Error("Stringify failed for section1, key3")
+		t.Error("Stringify failed for section1, key3")
 	}
 	db, found = d2.GetDouble("section2", "key1")
 	if !found || db != 5.0 {
-	        t.Error("Stringify failed for section2, key1")
+		t.Error("Stringify failed for section2, key1")
 	}
 }


### PR DESCRIPTION
Before this change, a line containing only spaces would result in a slice index of `-1` being used in the `for` loop condition on line 60, and thus a panic.

After this change, the code should be robust to such lines.